### PR TITLE
Allow putting tables in lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
-# docx2html
+=========
+docx2html
+=========
 
 Convert a docx (OOXML) file to semantic HTML.
 All of Word formatting nonsense is stripped away and
 you're left with a cleanly-formatted version of the content.
 
 
-## Usage
+Usage
+=====
 
     >>> from docx2html import convert
     >>> html = convert('path/to/docx/file')
 
 
-## Running Tests for Development
+Running Tests for Development
+=============================
 
 
 	$ virtualenv path/to/new/virtualenv
@@ -24,7 +28,8 @@ you're left with a cleanly-formatted version of the content.
     $ ./run_tests.sh
 
 
-## Description
+Description
+===========
 
 docx2html is designed to take a docx file and extract the content out and
 convert that content to html. It does not care about styles or fonts or
@@ -39,6 +44,8 @@ is a list of what currently works:
 * Lists
     * Nested lists
     * List styles (letters, roman numerals, etc.)
+    * Tables
+    * Paragraphs
 * Tables
     * Rowspans
     * Colspans
@@ -54,7 +61,8 @@ is a list of what currently works:
     * Root level lists that are upper case roman numerals get converted to h2
       tags
 
-### Handling embedded images
+Handling embedded images
+------------------------
 
 docx2html allows you to specify how you would like to handle image uploading.
 For example, you might be uploading your images to Amazon S3 eg:

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -1,6 +1,7 @@
 import cgi
 import os
 import os.path
+import re
 from PIL import Image
 from lxml import etree
 from lxml.etree import XMLSyntaxError
@@ -1343,8 +1344,12 @@ def create_html(tree, meta_data):
 
         # Keep track of visited_nodes
         visited_nodes.append(el)
-    return etree.tostring(
+    result = etree.tostring(
         new_html,
         method='html',
         with_tail=True,
     )
+
+    #XXX Hack not sure how to get etree to do this by default.
+    regex = re.compile(r'<br>')
+    return regex.sub('<br />', result)

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -259,6 +259,8 @@ def is_last_li(li, meta_data, current_numId):
         new_numId = get_numId(next_el, w_namespace)
         if current_numId != new_numId:
             return True
+        # If we have gotten here then we have found another list item in the
+        # current list, so ``li`` is not the last li in the list.
         return False
 
 
@@ -289,6 +291,7 @@ def get_li_nodes(li, meta_data):
         if is_last_li(el, meta_data, current_numId):
             new_numId = get_numId(el, w_namespace)
             if current_numId == new_numId:
+                # Not a subsequent list.
                 yield el
             break
 
@@ -863,6 +866,12 @@ def get_list_data(li_nodes, meta_data):
     root_ol = None
     visited_nodes = []
     texts = []
+
+    # Helper function
+    def _build_li(texts):
+        data = '<br/>'.join(t for t in texts if t is not None)
+        return etree.XML('<li>%s</li>' % data), []
+
     for li_node in li_nodes:
         w_namespace = get_namespace(li_node, 'w')
         if not is_li(li_node, meta_data):
@@ -882,10 +891,7 @@ def get_list_data(li_nodes, meta_data):
             visited_nodes.extend(el_visited_nodes)
             continue
         elif texts != []:
-            data = '<br/>'.join(t for t in texts if t is not None)
-            # Reset the texts list
-            texts = []
-            li_el = etree.XML('<li>%s</li>' % data)
+            li_el, texts = _build_li(texts)
             current_ol.append(li_el)
         # Get the data needed to build the current list item
         texts.append(get_p_data(
@@ -946,10 +952,7 @@ def get_list_data(li_nodes, meta_data):
         visited_nodes.extend(list(li_node.iter()))
 
     if texts != []:
-        data = '<br/>'.join(t for t in texts if t is not None)
-        # Reset the texts list
-        texts = []
-        li_el = etree.XML('<li>%s</li>' % data)
+        li_el, texts = _build_li(texts)
         current_ol.append(li_el)
 
     # Merge up any nested lists that have not been merged.

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -1351,5 +1351,15 @@ def create_html(tree, meta_data):
     )
 
     #XXX Hack not sure how to get etree to do this by default.
-    regex = re.compile(r'<br>')
-    return regex.sub('<br />', result)
+    void_tags = [
+        r'br',
+        r'img',
+    ]
+    for tag in void_tags:
+        regex = re.compile(r'<%s.*?>' % tag)
+        matches = regex.findall(result)
+        for match in matches:
+            new_tag = match.strip('<>')
+            new_tag = '<%s />' % new_tag
+            result = re.sub(match, new_tag, result)
+    return result

--- a/docx2html/exceptions.py
+++ b/docx2html/exceptions.py
@@ -12,3 +12,7 @@ class FileNotDocx(Docx2HtmlException):
 
 class MalformedDocx(Docx2HtmlException):
     pass
+
+
+class UnintendedTag(Docx2HtmlException):
+    pass

--- a/docx2html/tests/test_docx.py
+++ b/docx2html/tests/test_docx.py
@@ -425,7 +425,7 @@ def test_has_image():
     actual_html = convert(new_file_path)
     assert_html_equal(actual_html, '''
     <html>
-    <p>AAA<img src="%s/word/media/image1.gif" height="55" width="260"></p>
+    <p>AAA<img src="%s/word/media/image1.gif" height="55" width="260" /></p>
     </html>
     ''' % dp)
 
@@ -448,7 +448,7 @@ def test_has_image_using_image_handler():
     actual_html = convert(new_file_path, image_handler=image_handler)
     assert_html_equal(actual_html, '''
 
-    <html><p>AAA<img src="test" height="55" width="260"></p></html>
+    <html><p>AAA<img src="test" height="55" width="260" /></p></html>
     ''')
 
 

--- a/docx2html/tests/test_docx.py
+++ b/docx2html/tests/test_docx.py
@@ -324,19 +324,18 @@ def test_tables_in_lists():
     <html>
         <ol data-list-type="decimal">
             <li>AAA</li>
-            <li>BBB</li>
-        </ol>
-        <table>
-            <tr>
-                <td>CCC</td>
-                <td>DDD</td>
-            </tr>
-            <tr>
-                <td>EEE</td>
-                <td>FFF</td>
-            </tr>
-        </table>
-        <ol data-list-type="decimal">
+            <li>BBB<br>
+                <table>
+                    <tr>
+                        <td>CCC</td>
+                        <td>DDD</td>
+                    </tr>
+                    <tr>
+                        <td>EEE</td>
+                        <td>FFF</td>
+                    </tr>
+                </table>
+            </li>
             <li>GGG</li>
         </ol>
     </html>

--- a/docx2html/tests/test_docx.py
+++ b/docx2html/tests/test_docx.py
@@ -242,7 +242,7 @@ def test_nested_table_rowspan():
                             <td>EEE</td>
                         </tr>
                     </table>
-                    <br>
+                    <br />
                 </td>
             </tr>
         </table>
@@ -279,7 +279,7 @@ def test_nested_tables():
                   <td>GGG</td>
                 </tr>
               </table>
-              <br>
+              <br />
             </td>
           </tr>
         </table>
@@ -324,7 +324,7 @@ def test_tables_in_lists():
     <html>
         <ol data-list-type="decimal">
             <li>AAA</li>
-            <li>BBB<br>
+            <li>BBB<br />
                 <table>
                     <tr>
                         <td>CCC</td>
@@ -605,16 +605,16 @@ def test_shift_enter():
     actual_html = convert(file_path)
     assert_html_equal(actual_html, '''
     <html>
-        <p>AAA<br>BBB</p>
+        <p>AAA<br />BBB</p>
         <p>CCC</p>
         <ol data-list-type="decimal">
-            <li>DDD<br>EEE</li>
+            <li>DDD<br />EEE</li>
             <li>FFF</li>
         </ol>
         <table>
             <tr>
-                <td>GGG<br>HHH</td>
-                <td>III<br>JJJ</td>
+                <td>GGG<br />HHH</td>
+                <td>III<br />JJJ</td>
             </tr>
             <tr>
                 <td>KKK</td>

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -129,7 +129,7 @@ class TableInListTestCase(_TranslationTestCase):
     expected_output = '''
         <html>
             <ol data-list-type="decimal">
-                <li>AAA<br>
+                <li>AAA<br />
                     <table>
                         <tr>
                             <td>BBB</td>
@@ -384,8 +384,8 @@ class ListWithContinuationTestCase(_TranslationTestCase):
     expected_output = '''
         <html>
             <ol data-list-type="decimal">
-                <li>AAA<br>BBB</li>
-                <li>CCC<br>
+                <li>AAA<br />BBB</li>
+                <li>CCC<br />
                     <table>
                         <tr>
                             <td>DDD</td>

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -174,8 +174,7 @@ class TableInListTestCase(_TranslationTestCase):
         w_namespace = get_namespace(tree, 'w')
         first_p_tag = tree.find('%sp' % w_namespace)
 
-        # Currently, the nest should be split (two lists instead of one with a
-        # nested table in it)
+        # Show that list nesting deals with the table nesting
         li_data = get_li_nodes(first_p_tag, meta_data)
         assert len(list(li_data)) == 3
 

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -304,10 +304,10 @@ class ImageTestCase(_TranslationTestCase):
     expected_output = '''
         <html>
             <p>
-                <img src="media/image1.jpeg" height="4" width="4">
+                <img src="media/image1.jpeg" height="4" width="4" />
             </p>
             <p>
-                <img src="media/image2.jpeg" height="4" width="4">
+                <img src="media/image2.jpeg" height="4" width="4" />
             </p>
         </html>
     '''
@@ -371,10 +371,10 @@ class ImageTestCase(_TranslationTestCase):
         assert_html_equal(html, '''
             <html>
                 <p>
-                    <img src="media/image1.jpeg" height="4" width="4">
+                    <img src="media/image1.jpeg" height="4" width="4" />
                 </p>
                 <p>
-                    <img src="media/image2.jpeg" height="6" width="6">
+                    <img src="media/image2.jpeg" height="6" width="6" />
                 </p>
             </html>
         ''')
@@ -439,7 +439,7 @@ class PictImageTestCase(_TranslationTestCase):
     expected_output = '''
         <html>
             <p>
-                <img src="media/image1.jpeg" height="4" width="4">
+                <img src="media/image1.jpeg" height="4" width="4" />
             </p>
         </html>
     '''


### PR DESCRIPTION
Currently the behaviour is that if a you have a table in a list:

`<html>
            <ol>
                <li>AAA</li>
            </ol>
            <table>
                <tr>
                    <td>AAA</td>
                    <td>BBB</td>
                </tr>
                <tr>
                    <td>CCC</td>
                    <td>DDD</td>
                </tr>
            </table>
            <ol>
                <li>BBB</li>
            </ol>
        </html>
`

It breaks the list and makes three elements, the first half of the list, the table and the second half of the list. We should allow nesting the table (and other elements) in the list
