### PR TITLE
Add the ability to black list tags for in has_text

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@
 Changelog
 =========
 
+* 0.1.4
+    * Added a blacklist in has_text to ignore tags pertaining to headers/footers
 * 0.1.3
     * Hyperlinks with no text no longer throw an error
     * Fixed a bug with determining the font size with an incomplete styles dict

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,7 +3,8 @@ Changelog
 =========
 
 * 0.1.4
-    * Added a blacklist in has_text to ignore tags pertaining to headers/footers
+    * Added a function to remove tags, in addition stripped 'sectPr' tags since
+      they have to do with headers and footers.
 * 0.1.3
     * Hyperlinks with no text no longer throw an error
     * Fixed a bug with determining the font size with an incomplete styles dict

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -1266,26 +1266,8 @@ def _strip_tag(tree, tag):
     """
     Remove all tags that have the tag name ``tag``
     """
-    w_namespace = get_namespace(tree, 'w')
-
-    check_text = True
-    # There are some tags that even if they have text we want to ignore
-    # (tags related to headers and footers)
-    black_list = (
-        '%ssectPr' % w_namespace,
-    )
-    if tag in black_list:
-        # We do not care if these tags have text in them or not, remove them
-        # anyway.
-        check_text = False
     for el in tree:
-        remove_el = False
         if el.tag == tag:
-            # We can remove the element if we don't want to check the element
-            # for text, or if the tag in question does not have text.
-            if not check_text or not has_text(el):
-                remove_el = True
-        if remove_el:
             tree.remove(el)
 
 

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -250,6 +250,15 @@ def has_text(p):
     this is the case we do not want that tag interfering with things like
     lists. Detect if this tag has any content.
     """
+    w_namespace = get_namespace(p, 'w')
+
+    # There are some tags that even if they have text we want to ignore
+    # (tags related to headers and footers)
+    black_list = (
+        '%ssectPr' % w_namespace,
+    )
+    if p.tag in black_list:
+        return False
     return '' != etree.tostring(p, encoding=unicode, method='text').strip()
 
 
@@ -894,6 +903,7 @@ def get_list_data(li_nodes, meta_data):
         elif el.tag == '%sp' % w_namespace:
             return get_p_data(el, meta_data), [el]
         if has_text(el):
+            print etree.tostring(el, pretty_print=True)
             raise UnintendedTag('Did not expect %s' % el.tag)
 
     def _merge_lists(ilvl, current_ilvl, ol_dict, current_ol):

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -903,7 +903,6 @@ def get_list_data(li_nodes, meta_data):
         elif el.tag == '%sp' % w_namespace:
             return get_p_data(el, meta_data), [el]
         if has_text(el):
-            print etree.tostring(el, pretty_print=True)
             raise UnintendedTag('Did not expect %s' % el.tag)
 
     def _merge_lists(ilvl, current_ilvl, ol_dict, current_ol):

--- a/docx2html/tests/document_builder.py
+++ b/docx2html/tests/document_builder.py
@@ -7,6 +7,7 @@ templates = {
     'p': 'p.xml',
     'pict': 'pict.xml',
     'r': 'r.xml',
+    'sectPr': 'sectPr.xml',
     'table': 'table.xml',
     'tc': 'tc.xml',
     'tr': 'tr.xml',
@@ -108,3 +109,12 @@ class DocxBuilder(object):
     def pict(self, r_id=None):
         template = env.get_template(templates['pict'])
         return template.render(r_id=r_id)
+
+    @classmethod
+    def sectPr_tag(self, p_tag):
+        template = env.get_template(templates['sectPr'])
+
+        kwargs = {
+            'p_tag': p_tag,
+        }
+        return template.render(**kwargs)

--- a/docx2html/tests/templates/sectPr.xml
+++ b/docx2html/tests/templates/sectPr.xml
@@ -1,0 +1,3 @@
+<w:sectPr xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+	{{ p_tag }}
+</w:sectPr>

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -565,7 +565,6 @@ class HeaderFooterTagsWithContent(_TranslationTestCase):
         <ol data-list-type="decimal">
             <li>AAA</li>
         </ol>
-        <p>BBB</p>
     </html>
     '''
 

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -557,3 +557,22 @@ class MissingFontInfoTestCase(_TranslationTestCase):
             get_font_size(p_tag, {}),
             None,
         )
+
+
+class HeaderFooterTagsWithContent(_TranslationTestCase):
+    expected_output = '''
+    <html>
+        <ol data-list-type="decimal">
+            <li>AAA</li>
+        </ol>
+        <p>BBB</p>
+    </html>
+    '''
+
+    def get_xml(self):
+        li = DXB.li(text='AAA', ilvl=0, numId=1)
+        p_tag = DXB.p_tag('BBB')
+        footer_tag = DXB.sectPr_tag(p_tag)
+        body = li + footer_tag
+        xml = DXB.xml(body)
+        return etree.fromstring(xml)


### PR DESCRIPTION
Sometimes a tag will be checked to see if it has text and we don't care if it does or not (it has to do with header/footer info) if this happens always return False.
