### PR TITLE
Make heading detection case insensitve

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* 0.1.6
+    * Header detection was relying on case. However it is possible for a lower
+      case version of headers to show up. Those are now handled correctly.
 * 0.1.4
     * Added a function to remove tags, in addition stripped 'sectPr' tags since
       they have to do with headers and footers.

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -659,16 +659,16 @@ def get_style_dict(tree):
     # This is a partial document and actual h1 is the document title, which
     # will be displayed elsewhere.
     headers = {
-        'Heading 1': 'h2',
-        'Heading 2': 'h3',
-        'Heading 3': 'h4',
-        'Heading 4': 'h5',
-        'Heading 5': 'h6',
-        'Heading 6': 'h6',
-        'Heading 7': 'h6',
-        'Heading 8': 'h6',
-        'Heading 9': 'h6',
-        'Heading 10': 'h6',
+        'heading 1': 'h2',
+        'heading 2': 'h3',
+        'heading 3': 'h4',
+        'heading 4': 'h5',
+        'heading 5': 'h6',
+        'heading 6': 'h6',
+        'heading 7': 'h6',
+        'heading 8': 'h6',
+        'heading 9': 'h6',
+        'heading 10': 'h6',
     }
     if tree is None:
         return {}
@@ -685,7 +685,7 @@ def get_style_dict(tree):
         name = el.find('%sname' % w_namespace)
         if name is None:
             continue
-        value = name.get('%sval' % w_namespace)
+        value = name.get('%sval' % w_namespace).lower()
         if value in headers:
             el_result['header'] = headers[value]
 

--- a/docx2html/tests/document_builder.py
+++ b/docx2html/tests/document_builder.py
@@ -11,6 +11,8 @@ templates = {
     'table': 'table.xml',
     'tc': 'tc.xml',
     'tr': 'tr.xml',
+    'styles': 'styles.xml',
+    'style': 'style.xml',
 }
 
 env = Environment(
@@ -117,4 +119,24 @@ class DocxBuilder(object):
         kwargs = {
             'p_tag': p_tag,
         }
+        return template.render(**kwargs)
+
+    @classmethod
+    def styles_xml(self, style_tags):
+        template = env.get_template(templates['styles'])
+
+        kwargs = {
+            'style_tags': style_tags,
+        }
+        return template.render(**kwargs)
+
+    @classmethod
+    def style(self, style_id, value):
+        template = env.get_template(templates['style'])
+
+        kwargs = {
+            'style_id': style_id,
+            'value': value,
+        }
+
         return template.render(**kwargs)

--- a/docx2html/tests/templates/style.xml
+++ b/docx2html/tests/templates/style.xml
@@ -1,0 +1,15 @@
+<w:style w:styleId="{{ style_id }}">
+	<w:name w:val="{{ value }}"/>
+	<w:basedOn w:val="Normal"/>
+	<w:next w:val="Normal"/>
+	<w:pPr>
+		<w:ind w:hanging="461"/>
+		<w:ind w:left="485"/>
+		<w:spacing w:after="60"/>
+		<w:spacing w:before="61"/>
+	</w:pPr>
+	<w:rPr>
+		<w:sz w:val="24"/>
+		<w:rFonts w:ascii="Times New Roman" w:cs="Times New Roman" w:hAnsi="Times New Roman"/>
+	</w:rPr>
+</w:style>

--- a/docx2html/tests/templates/styles.xml
+++ b/docx2html/tests/templates/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<w:styles xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+	{% for style in style_tags %}
+		{{ style }}
+	{% endfor %}
+</w:styles>

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -6,6 +6,7 @@ from copy import copy
 from docx2html.core import (
     _is_top_level_upper_roman,
     create_html,
+    get_style_dict,
     get_font_size,
     get_image_id,
     get_li_nodes,
@@ -575,3 +576,20 @@ class HeaderFooterTagsWithContent(_TranslationTestCase):
         body = li + footer_tag
         xml = DXB.xml(body)
         return etree.fromstring(xml)
+
+
+class StylesParsingTestCase(_TranslationTestCase):
+    expected_output = '<html></html>'
+
+    def get_xml(self):
+        return etree.fromstring(DXB.xml(''))
+
+    def test_get_headings(self):
+
+        styles = [
+            DXB.style('heading 1', 'heading 1'),
+        ]
+        xml = DXB.styles_xml(styles)
+        styles_xml = etree.fromstring(xml)
+        styles_dict = get_style_dict(styles_xml)
+        self.assertEqual(styles_dict['heading 1']['header'], 'h2')


### PR DESCRIPTION
In `get_style_dict` when we are determining if a p tag is actually a heading tag it was assuming that the value of the style would be `Heading \d` with an upper case H. However it is possible for the style to be `heading \d`. This needs to be handled
