### PR TITLE
Deal with invalid list id/indent level combinations.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+* 0.1.7
+    * If the indentation level of a set of lists (with the same list id) were
+      mangled (Starting off with a higher indentation level followed by a
+      lower) then the entire sub list (the list with the lower indentation
+      level) would not be added to the root list, thusly removing it from the
+      final output. This issue has been addressed.
 * 0.1.6
     * Header detection was relying on case. However it is possible for a lower
       case version of headers to show up. Those are now handled correctly.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,8 +6,8 @@ Changelog
     * If the indentation level of a set of lists (with the same list id) were
       mangled (Starting off with a higher indentation level followed by a
       lower) then the entire sub list (the list with the lower indentation
-      level) would not be added to the root list, thusly removing it from the
-      final output. This issue has been addressed.
+      level) would not be added to the root list. This would result in removing
+      the mangled list from the final output. This issue has been addressed.
 * 0.1.6
     * Header detection was relying on case. However it is possible for a lower
       case version of headers to show up. Those are now handled correctly.

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -912,15 +912,6 @@ def get_list_data(li_nodes, meta_data):
                 del ol_dict[key]
         return current_ol
 
-    def _current_ol_in_root_ol():
-        # Checking to see if current_ol in root_ol does not work. Loop
-        # through each of the elements in root_ol and return true if one
-        # of them is current ol.
-        for el in root_ol:
-            if current_ol is root_ol:
-                return True
-        return False
-
     for li_node in li_nodes:
         w_namespace = get_namespace(li_node, 'w')
         if not is_li(li_node, meta_data):
@@ -1001,7 +992,7 @@ def get_list_data(li_nodes, meta_data):
         current_ol=current_ol,
     )
 
-    if not _current_ol_in_root_ol():
+    if current_ol is not root_ol:
         root_ol[-1].append(current_ol)
 
     return root_ol, visited_nodes

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -165,8 +165,7 @@ def is_natural_header(el, styles_dict):
     if (
             style_id in styles_dict and
             'header' in styles_dict[style_id] and
-            styles_dict[style_id]['header']
-        ):
+            styles_dict[style_id]['header']):
         return styles_dict[style_id]['header']
 
 
@@ -309,7 +308,6 @@ def get_li_nodes(li, meta_data):
                 # Not a subsequent list.
                 yield el
             break
-
         yield el
 
 
@@ -1018,8 +1016,7 @@ def get_tr_data(tr, meta_data, row_spans):
             # ignored.
             if (
                     v_merge is not None and
-                    v_merge.get('%sval' % w_namespace) != 'restart'
-                ):
+                    v_merge.get('%sval' % w_namespace) != 'restart'):
                 continue
 
             # Loop through each and build a list of all the content.
@@ -1072,8 +1069,7 @@ def get_tr_data(tr, meta_data, row_spans):
             # here.
             if (
                     v_merge is not None and
-                    v_merge.get('%sval' % w_namespace) == 'restart'
-                ):
+                    v_merge.get('%sval' % w_namespace) == 'restart'):
                 rowspan = next(row_spans)
                 td_el.set('rowspan', '%d' % rowspan)
 

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -286,6 +286,7 @@ def get_li_nodes(li, meta_data):
     yield li
     w_namespace = get_namespace(li, 'w')
     current_numId = get_numId(li, w_namespace)
+    starting_ilvl = get_ilvl(li, w_namespace)
     el = li
     while True:
         el = el.getnext()
@@ -298,6 +299,11 @@ def get_li_nodes(li, meta_data):
         # Stop the lists if you come across a list item that should be a
         # heading.
         if _is_top_level_upper_roman(el, meta_data):
+            break
+
+        if (
+                is_li(el, meta_data) and
+                (starting_ilvl > get_ilvl(el, w_namespace))):
             break
 
         # If the list id of the next tag is different that the previous that
@@ -991,9 +997,6 @@ def get_list_data(li_nodes, meta_data):
         ol_dict=ol_dict,
         current_ol=current_ol,
     )
-
-    if current_ol is not root_ol:
-        root_ol[-1].append(current_ol)
 
     return root_ol, visited_nodes
 

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -912,6 +912,15 @@ def get_list_data(li_nodes, meta_data):
                 del ol_dict[key]
         return current_ol
 
+    def _current_ol_in_root_ol():
+        # Checking to see if current_ol in root_ol does not work. Loop
+        # through each of the elements in root_ol and return true if one
+        # of them is current ol.
+        for el in root_ol:
+            if current_ol is root_ol:
+                return True
+        return False
+
     for li_node in li_nodes:
         w_namespace = get_namespace(li_node, 'w')
         if not is_li(li_node, meta_data):
@@ -991,6 +1000,9 @@ def get_list_data(li_nodes, meta_data):
         ol_dict=ol_dict,
         current_ol=current_ol,
     )
+
+    if not _current_ol_in_root_ol():
+        root_ol[-1].append(current_ol)
 
     return root_ol, visited_nodes
 

--- a/docx2html/tests/test_docx.py
+++ b/docx2html/tests/test_docx.py
@@ -33,8 +33,7 @@ def test_extract_html():
         'simple.docx',
     )
     actual_html = convert(file_path)
-    assert_html_equal(actual_html,
-    '''
+    assert_html_equal(actual_html, '''
     <html>
         <p>
           Simple text
@@ -66,8 +65,7 @@ def test_nested_list():
         'nested_lists.docx',
     )
     actual_html = convert(file_path)
-    assert_html_equal(actual_html,
-    '''
+    assert_html_equal(actual_html, '''
     <html>
         <ol data-list-type="decimal">
             <li>one</li>
@@ -111,8 +109,7 @@ def test_simple_list():
         'simple_lists.docx',
     )
     actual_html = convert(file_path)
-    assert_html_equal(actual_html,
-    '''
+    assert_html_equal(actual_html, '''
     <html>
         <ol data-list-type="decimal">
             <li>One</li>
@@ -132,8 +129,7 @@ def test_inline_tags():
         'inline_tags.docx',
     )
     actual_html = convert(file_path)
-    assert_html_equal(actual_html,
-    '''
+    assert_html_equal(actual_html, '''
     <html><p>This sentence has some <strong>bold</strong>, some <em>italics</em> and some <strong>underline</strong>, as well as a <a href="http://www.google.com/">hyperlink</a>.</p></html>''')  # noqa
 
 

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -602,11 +602,10 @@ class MangledIlvlTestCase(_TranslationTestCase):
             <li>AAA</li>
         </ol>
         <ol data-list-type="decimal">
-            <li>BBB
-                <ol data-list-type="decimal">
-                    <li>CCC</li>
-                </ol>
-            </li>
+            <li>BBB</li>
+        </ol>
+        <ol data-list-type="decimal">
+            <li>CCC</li>
         </ol>
     </html>
     '''

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -593,3 +593,33 @@ class StylesParsingTestCase(_TranslationTestCase):
         styles_xml = etree.fromstring(xml)
         styles_dict = get_style_dict(styles_xml)
         self.assertEqual(styles_dict['heading 1']['header'], 'h2')
+
+
+class MangledIlvlTestCase(_TranslationTestCase):
+    expected_output = '''
+    <html>
+        <ol data-list-type="decimal">
+            <li>AAA</li>
+        </ol>
+        <ol data-list-type="decimal">
+            <li>BBB
+                <ol data-list-type="decimal">
+                    <li>CCC</li>
+                </ol>
+            </li>
+        </ol>
+    </html>
+    '''
+
+    def get_xml(self):
+        li_text = [
+            ('AAA', 0, 2),
+            ('BBB', 1, 1),
+            ('CCC', 0, 1),
+        ]
+        lis = ''
+        for text, ilvl, numId in li_text:
+            lis += DXB.li(text=text, ilvl=ilvl, numId=numId)
+
+        xml = DXB.xml(lis)
+        return etree.fromstring(xml)


### PR DESCRIPTION
Currently if you have a list structure such that you have:

Li one
numId:1
ilvl: 1

followed by

Li two
numId:1
ilvl: 0

The fact that they are the same list id, but with reverse indentation level, the second li will not be added to the resulting list.
