### PR TITLE
Missing content for certain lists

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,9 @@
 Changelog
 =========
 
+* 0.1.9
+    * There was a problem for some lists that would cause missing content if
+      the list id's were not well behaved. This issue has been addressed.
 * 0.1.8
     * Fixed missing content with hyperlinks with more than one run tag and
       smartTags.

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -313,13 +313,18 @@ def get_li_nodes(li, meta_data):
                 (starting_ilvl > get_ilvl(el, w_namespace))):
             break
 
+        new_numId = get_numId(el, w_namespace)
+        if new_numId is None or new_numId == -1:
+            # Not a p tag or a list item
+            yield el
+            continue
         # If the list id of the next tag is different that the previous that
         # means a new list being made (not nested)
+        if current_numId != new_numId:
+            # Not a subsequent list.
+            break
         if is_last_li(el, meta_data, current_numId):
-            new_numId = get_numId(el, w_namespace)
-            if current_numId == new_numId:
-                # Not a subsequent list.
-                yield el
+            yield el
             break
         yield el
 

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -710,3 +710,35 @@ class MangledIlvlTestCase(_TranslationTestCase):
 
         xml = DXB.xml(lis)
         return etree.fromstring(xml)
+
+
+class SeperateListsTestCase(_TranslationTestCase):
+    expected_output = '''
+    <html>
+        <ol data-list-type="decimal">
+            <li>AAA</li>
+        </ol>
+        <ol data-list-type="decimal">
+            <li>BBB</li>
+        </ol>
+        <ol data-list-type="decimal">
+            <li>CCC</li>
+        </ol>
+    </html>
+    '''
+
+    def get_xml(self):
+        li_text = [
+            ('AAA', 0, 2),
+            # Because AAA and CCC are part of the same list (same list id)
+            # and BBB is different, these need to be split into three
+            # lists (or lose everything from BBB and after.
+            ('BBB', 0, 1),
+            ('CCC', 0, 2),
+        ]
+        lis = ''
+        for text, ilvl, numId in li_text:
+            lis += DXB.li(text=text, ilvl=ilvl, numId=numId)
+
+        xml = DXB.xml(lis)
+        return etree.fromstring(xml)


### PR DESCRIPTION
If you have 

li numid 1
li numid 0
li numid 1

Everything after the first li is dropped.
