### PR TITLE
Determing list type can cause a key error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-* 0.1.12
+* 0.2.0
     * If a list had a numId that was not stored in the numbering dict, then a
       key error would be thrown. Now if either the numId or the ilvl for a
       given list tag is invalid it defaults to returning a list type of

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+* 0.1.12
+    * If a list had a numId that was not stored in the numbering dict, then a
+      key error would be thrown. Now if either the numId or the ilvl for a
+      given list tag is invalid it defaults to returning a list type of
+      decimal.
 * 0.1.11
     * Sometimes in the OOXML an image will have a height or width of 0. If this
       happens we are now ignoring the height and width in the OOXML and using

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -22,6 +22,7 @@ DETECT_FONT_SIZE = False
 EMUS_PER_PIXEL = 9525
 NSMAP = {}
 IMAGE_EXTENSIONS_TO_SKIP = ['emf', 'wmf', 'svg']
+DEFAULT_LIST_NUMBERING_STYLE = 'decimal'
 
 logger = logging.getLogger(__name__)
 
@@ -370,20 +371,20 @@ def create_list(list_type):
     el = etree.Element(list_types.get(list_type, 'ol'))
     # These are the supported list style types and their conversion to css.
     list_type_conversions = {
-        'decimal': 'decimal',
+        'decimal': DEFAULT_LIST_NUMBERING_STYLE,
         'decimalZero': 'decimal-leading-zero',
         'upperRoman': 'upper-roman',
         'lowerRoman': 'lower-roman',
         'upperLetter': 'upper-alpha',
         'lowerLetter': 'lower-alpha',
-        'ordinal': 'decimal',
-        'cardinalText': 'decimal',
-        'ordinalText': 'decimal',
+        'ordinal': DEFAULT_LIST_NUMBERING_STYLE,
+        'cardinalText': DEFAULT_LIST_NUMBERING_STYLE,
+        'ordinalText': DEFAULT_LIST_NUMBERING_STYLE,
     }
     if list_type != 'bullet':
         el.set(
             'data-list-type',
-            list_type_conversions.get(list_type, 'decimal'),
+            list_type_conversions.get(list_type, DEFAULT_LIST_NUMBERING_STYLE),
         )
     return el
 
@@ -890,8 +891,16 @@ def get_list_type(meta_data, numId, ilvl):
     """
     Return the list type. If numId or ilvl not in the numbering dict then
     default to returning decimal.
+
+    This function only cares about ordered lists, unordered lists get dealt
+    with elsewhere.
     """
-    return meta_data.numbering_dict.get(numId, {}).get(ilvl, 'decimal')
+    numbering_dict = meta_data.numbering_dict
+    if numId not in numbering_dict:
+        return DEFAULT_LIST_NUMBERING_STYLE
+    if ilvl not in numbering_dict[numId]:
+        return DEFAULT_LIST_NUMBERING_STYLE
+    return meta_data.numbering_dict[numId][ilvl]
 
 
 def get_list_data(li_nodes, meta_data):

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -895,6 +895,8 @@ def get_list_type(meta_data, numId, ilvl):
     This function only cares about ordered lists, unordered lists get dealt
     with elsewhere.
     """
+
+    # Early return if numId or ilvl are not valid
     numbering_dict = meta_data.numbering_dict
     if numId not in numbering_dict:
         return DEFAULT_LIST_NUMBERING_STYLE

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -887,7 +887,7 @@ def _get_document_data(f, image_handler=None):
 ###
 
 
-def get_list_type(meta_data, numId, ilvl):
+def get_ordered_list_type(meta_data, numId, ilvl):
     """
     Return the list type. If numId or ilvl not in the numbering dict then
     default to returning decimal.
@@ -980,7 +980,7 @@ def get_list_data(li_nodes, meta_data):
         ))
         ilvl = get_ilvl(li_node, w_namespace)
         numId = get_numId(li_node, w_namespace)
-        list_type = get_list_type(meta_data, numId, ilvl)
+        list_type = get_ordered_list_type(meta_data, numId, ilvl)
 
         # If the ilvl is greater than the current_ilvl or the list id is
         # changing then we have the first li tag in a nested list. We need to

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -886,6 +886,14 @@ def _get_document_data(f, image_handler=None):
 ###
 
 
+def get_list_type(meta_data, numId, ilvl):
+    """
+    Return the list type. If numId or ilvl not in the numbering dict then
+    default to returning decimal.
+    """
+    return meta_data.numbering_dict.get(numId, {}).get(ilvl, 'decimal')
+
+
 def get_list_data(li_nodes, meta_data):
     """
     Build the list structure and return the root list
@@ -961,7 +969,7 @@ def get_list_data(li_nodes, meta_data):
         ))
         ilvl = get_ilvl(li_node, w_namespace)
         numId = get_numId(li_node, w_namespace)
-        list_type = meta_data.numbering_dict[numId].get(ilvl, 'decimal')
+        list_type = get_list_type(meta_data, numId, ilvl)
 
         # If the ilvl is greater than the current_ilvl or the list id is
         # changing then we have the first li tag in a nested list. We need to

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -5,6 +5,7 @@ from lxml import etree
 from copy import copy
 
 from docx2html.core import (
+    DEFAULT_LIST_NUMBERING_STYLE,
     _is_top_level_upper_roman,
     convert_image,
     create_html,
@@ -74,7 +75,7 @@ class SimpleListTestCase(_TranslationTestCase):
             [False, False, True],
         )
 
-    def test_get_list_type(self):
+    def test_get_list_type_valid(self):
         meta_data = self.get_meta_data()
         numId = '1'
         ilvl = 0
@@ -84,29 +85,29 @@ class SimpleListTestCase(_TranslationTestCase):
         list_type = get_list_type(meta_data, numId, ilvl)
         self.assertEqual(list_type, 'lowerLetter')
 
-        # Show that if the numId and/or the ilvl are invalid (not in the dict)
-        # that we still get a value (defaults to decimal)
-
-        # Invalid numId
+    def test_get_list_type_invalid_numId(self):
+        meta_data = self.get_meta_data()
         numId = '2'  # Not valid
         ilvl = 0
 
         list_type = get_list_type(meta_data, numId, ilvl)
-        self.assertEqual(list_type, 'decimal')
+        self.assertEqual(list_type, DEFAULT_LIST_NUMBERING_STYLE)
 
-        # Invalid ilvl
+    def test_get_list_type_invalid_ilvl(self):
+        meta_data = self.get_meta_data()
         numId = '1'
         ilvl = 1  # Not valid
 
         list_type = get_list_type(meta_data, numId, ilvl)
-        self.assertEqual(list_type, 'decimal')
+        self.assertEqual(list_type, DEFAULT_LIST_NUMBERING_STYLE)
 
-        # Both invalid
+    def test_get_list_type_invalid_numId_and_ilvl(self):
+        meta_data = self.get_meta_data()
         numId = '2'  # Not valid
         ilvl = 1  # Not valid
 
         list_type = get_list_type(meta_data, numId, ilvl)
-        self.assertEqual(list_type, 'decimal')
+        self.assertEqual(list_type, DEFAULT_LIST_NUMBERING_STYLE)
 
 
 class TableInListTestCase(_TranslationTestCase):

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -12,7 +12,7 @@ from docx2html.core import (
     get_font_size,
     get_image_id,
     get_li_nodes,
-    get_list_type,
+    get_ordered_list_type,
     get_namespace,
     get_relationship_info,
     get_style_dict,
@@ -82,7 +82,7 @@ class SimpleListTestCase(_TranslationTestCase):
 
         # Show that for a valid combination of numId and ilvl that you get the
         # correct list type.
-        list_type = get_list_type(meta_data, numId, ilvl)
+        list_type = get_ordered_list_type(meta_data, numId, ilvl)
         self.assertEqual(list_type, 'lowerLetter')
 
     def test_get_list_type_invalid_numId(self):
@@ -90,7 +90,7 @@ class SimpleListTestCase(_TranslationTestCase):
         numId = '2'  # Not valid
         ilvl = 0
 
-        list_type = get_list_type(meta_data, numId, ilvl)
+        list_type = get_ordered_list_type(meta_data, numId, ilvl)
         self.assertEqual(list_type, DEFAULT_LIST_NUMBERING_STYLE)
 
     def test_get_list_type_invalid_ilvl(self):
@@ -98,7 +98,7 @@ class SimpleListTestCase(_TranslationTestCase):
         numId = '1'
         ilvl = 1  # Not valid
 
-        list_type = get_list_type(meta_data, numId, ilvl)
+        list_type = get_ordered_list_type(meta_data, numId, ilvl)
         self.assertEqual(list_type, DEFAULT_LIST_NUMBERING_STYLE)
 
     def test_get_list_type_invalid_numId_and_ilvl(self):
@@ -106,7 +106,7 @@ class SimpleListTestCase(_TranslationTestCase):
         numId = '2'  # Not valid
         ilvl = 1  # Not valid
 
-        list_type = get_list_type(meta_data, numId, ilvl)
+        list_type = get_ordered_list_type(meta_data, numId, ilvl)
         self.assertEqual(list_type, DEFAULT_LIST_NUMBERING_STYLE)
 
 

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -11,6 +11,7 @@ from docx2html.core import (
     get_font_size,
     get_image_id,
     get_li_nodes,
+    get_list_type,
     get_namespace,
     get_relationship_info,
     get_style_dict,
@@ -26,13 +27,20 @@ from docx2html.tests import (
 class SimpleListTestCase(_TranslationTestCase):
     expected_output = '''
         <html>
-            <ol data-list-type="decimal">
+            <ol data-list-type="lower-alpha">
                 <li>AAA</li>
                 <li>BBB</li>
                 <li>CCC</li>
             </ol>
         </html>
     '''
+
+    # Ensure its not failing somewhere and falling back to decimal
+    numbering_dict = {
+        '1': {
+            0: 'lowerLetter',
+        }
+    }
 
     def get_xml(self):
         li_text = [
@@ -65,6 +73,40 @@ class SimpleListTestCase(_TranslationTestCase):
             result,
             [False, False, True],
         )
+
+    def test_get_list_type(self):
+        meta_data = self.get_meta_data()
+        numId = '1'
+        ilvl = 0
+
+        # Show that for a valid combination of numId and ilvl that you get the
+        # correct list type.
+        list_type = get_list_type(meta_data, numId, ilvl)
+        self.assertEqual(list_type, 'lowerLetter')
+
+        # Show that if the numId and/or the ilvl are invalid (not in the dict)
+        # that we still get a value (defaults to decimal)
+
+        # Invalid numId
+        numId = '2'  # Not valid
+        ilvl = 0
+
+        list_type = get_list_type(meta_data, numId, ilvl)
+        self.assertEqual(list_type, 'decimal')
+
+        # Invalid ilvl
+        numId = '1'
+        ilvl = 1  # Not valid
+
+        list_type = get_list_type(meta_data, numId, ilvl)
+        self.assertEqual(list_type, 'decimal')
+
+        # Both invalid
+        numId = '2'  # Not valid
+        ilvl = 1  # Not valid
+
+        list_type = get_list_type(meta_data, numId, ilvl)
+        self.assertEqual(list_type, 'decimal')
 
 
 class TableInListTestCase(_TranslationTestCase):


### PR DESCRIPTION
When we do `meta_data.numbering_dict[numId].get(ilvl, 'decimal')` if `numId` is not in the `numbering_dict` for whatever reason then this will throw a key error.
