### PR TITLE
Correctly handle lists with mangled ilvls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+* 0.2.1
+    * If a list had an inconsistency in the ilvls, the content for the
+      inconsistent ilvl would be lost. Now we roll that inconsistent list into
+      the root, no longer losing the content.
 * 0.2.0
     * If a list had a numId that was not stored in the numbering dict, then a
       key error would be thrown. Now if either the numId or the ilvl for a

--- a/docx2html/core.py
+++ b/docx2html/core.py
@@ -1013,11 +1013,18 @@ def get_list_data(li_nodes, meta_data):
         else:
             # In some instances the ilvl is not in the ol_dict, if that is the
             # case, create it here (not sure how this happens but it has
-            # before.)
-            ol_dict[ilvl] = create_list(list_type)
-            current_ilvl = ilvl
-            current_numId = numId
-            current_ol = ol_dict[ilvl]
+            # before.) Only do this if the current_ol is not the root_ol,
+            # otherwise etree will crash.
+
+            if current_ol is not root_ol:
+
+                # Merge the current_ol into the root_ol. _merge_lists is not
+                # equipped to handle this situation since the only way to get
+                # into this block of code is to have mangled ilvls.
+                root_ol[-1].append(current_ol)
+
+                # Reset the current_ol
+                current_ol = create_list(list_type)
 
         # Create the li element.
         visited_nodes.extend(list(li_node.iter()))

--- a/docx2html/tests/test_xml.py
+++ b/docx2html/tests/test_xml.py
@@ -827,3 +827,33 @@ class SeperateListsTestCase(_TranslationTestCase):
 
         xml = DXB.xml(lis)
         return etree.fromstring(xml)
+
+
+class InvalidIlvlOrderTestCase(_TranslationTestCase):
+    expected_output = '''
+    <html>
+        <ol data-list-type="decimal">
+            <li>AAA
+                <ol data-list-type="decimal">
+                    <li>BBB</li>
+                </ol>
+                <ol data-list-type="decimal">
+                    <li>CCC</li>
+                </ol>
+            </li>
+        </ol>
+    </html>
+    '''
+
+    def get_xml(self):
+        tags = [
+            DXB.li(text='AAA', ilvl=1, numId=1),
+            DXB.li(text='BBB', ilvl=3, numId=1),
+            DXB.li(text='CCC', ilvl=2, numId=1),
+        ]
+        body = ''
+        for el in tags:
+            body += el
+
+        xml = DXB.xml(body)
+        return etree.fromstring(xml)


### PR DESCRIPTION
If you have a series of lists such that

```
<w:numPr>
    <w:ilvl w:val="1"/>
    <w:numId w:val="1"/>
    AAA
</w:numPr>
<w:numPr>
    <w:ilvl w:val="3"/>
    <w:numId w:val="1"/>
    BBB
</w:numPr>
<w:numPr>
    <w:ilvl w:val="2"/>
    <w:numId w:val="1"/>
    CCC
</w:numPr>

```

Currently that will create a list structure of:

```
<ol>
    <li>AAA
         <ol>
               <li>CCC</li>
         </ol>
     </li>
</ol>


```

What we want to see instead is:

```
<ol>
    <li>AAA
         <ol>
               <li>BBB</li>
         </ol>
         <ol>
               <li>CCC</li>
         </ol>
     </li>
</ol>

```
